### PR TITLE
Add C++11 flags for gcc version < 6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,15 @@ if(CUDA_FOUND)
     #set(CMAKE_CXX_FLAGS "-stdlib=libstdc++")
   endif (UNIX)
 
+  # Support g++ versions less than 6.0
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+      set (CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++11")
+      set (CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-std=c++11")
+      set (CUDA_PROPAGATE_HOST_FLAGS OFF)
+    endif()
+  endif()
+
   # add debugging to CUDA NVCC flags.  For NVidia's NSight tools.
   set(CUDA_NVCC_FLAGS_DEBUG ${CUDA_NVCC_FLAGS_DEBUG} "-G")
 


### PR DESCRIPTION
One of my computers has to run CUDA 8 and gcc 4.8.5 to support another codebase. Added Cmake settings to support that older Maxwell card plus g++ 4.8.5, as opposed to Pascal + g++-6 on main machine